### PR TITLE
Update SERVER_LAUNCH_SCRIPT to enable metrics from release builds, fi…

### DIFF
--- a/cdk/multiplayer_test_scaler/constants.py
+++ b/cdk/multiplayer_test_scaler/constants.py
@@ -22,8 +22,8 @@ SERVER_LAUNCH_SCRIPT = '<script>\n' \
                        '@echo off\n' \
                        'netsh advfirewall firewall add rule name="O3DE_server" dir=in protocol=UDP localport={server_port} action=allow program="C:\o3de\{project_name}.ServerLauncher.exe" enable=yes\n' \
                        'cd C:/o3de\n' \
-                       '{project_name}.ServerLauncher --engine-path=C:\o3de --project-path=C:\o3de --project-cache-path=C:\o3de\Cache ' \
-                       '--regset="/Amazon/AWSCore/AllowAWSMetadataCredentials=true" ' \
+                       'start /b {project_name}.ServerLauncher --engine-path=C:\o3de --project-path=C:\o3de --project-cache-path=C:\o3de\Cache ' \
+                       '--regset="/Amazon/AWSCore/AllowAWSMetadataCredentials=true" --regset="/O3DE/Metrics/Multiplayer/Active=true" ' \
                        '--console-command-file=C:/o3de/Cache/pc/launch_server.cfg --rhi=null -NullRenderer -bg_ConnectToAssetProcessor=0 \n' \
                        '</script>'
 SERVER_INSTANCE_CLASS = ec2.InstanceClass.COMPUTE5


### PR DESCRIPTION
Previously, the AWS Systems Manager agent (which is included by default on the base Windows AMI we're building the server on), could not initialize because the server launch script was not being run as a background process on start up. This change backgrounds the server execution command to allow the agent initialization to proceed.

Also adds a settings registry value to enable O3DE multiplayer metrics generation for release builds, which is what this tool builds by default.

## Testing
 - server target deploys
 - while RDP'd into server, can see AWS SSM agent running in task manager
 - am able to connect to server instance directly from the EC2 console "Connect" dialog for AWS SSM connection
 - _/user/Metrics/server_network_metrics.json_ file is populated with metrics after server start